### PR TITLE
Refactor location handling and update main screen UI

### DIFF
--- a/app/src/main/java/com/hereliesaz/noobwifinder/MainViewModel.kt
+++ b/app/src/main/java/com/hereliesaz/noobwifinder/MainViewModel.kt
@@ -33,6 +33,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     private val _isCracking = MutableLiveData<Boolean>(false)
     val isCracking: LiveData<Boolean> = _isCracking
 
+    private val _isGeneratingFromLocation = MutableLiveData<Boolean>(false)
+    val isGeneratingFromLocation: LiveData<Boolean> = _isGeneratingFromLocation
+
     private var crackingJob: Job? = null
     private var fetchAddressesJob: Job? = null
 
@@ -124,6 +127,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
     fun onMapBoundsChanged(boundingBox: BoundingBox) {
         fetchAddressesJob?.cancel() // Cancel previous job
         fetchAddressesJob = viewModelScope.launch {
+            _isGeneratingFromLocation.postValue(true)
             delay(500) // Debounce for 500ms
             _logMessages.postValue("Fetching addresses in bounds...")
             val addresses = fetchAddressesInBounds(boundingBox)
@@ -135,6 +139,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             } else {
                 _logMessages.postValue("No addresses found in the visible area.")
             }
+            _isGeneratingFromLocation.postValue(false)
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -98,7 +98,7 @@
             android:id="@+id/map_card"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:cardCornerRadius="200dp"
+            app:cardCornerRadius="0dp"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintWidth_percent="0.9"
             app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
This commit refactors the location handling logic to simplify the user experience.

- Removes the stateful "manual location mode".
- The main screen map is now non-interactive.
- The map card is now rectangular and acts as a trigger for the Wi-Fi scan.
- The "Choose Location" screen now triggers a one-time password generation for the selected area.
- Adds state management to disable the scan button during password generation from a chosen location.